### PR TITLE
Fixed permission error

### DIFF
--- a/pkg.sh
+++ b/pkg.sh
@@ -7,5 +7,6 @@ OUTPUT=netease-cloud-music_1.0.0-2_amd64.deb
 dpkg-deb -x $DEB $TMP
 dpkg-deb --control $DEB $TMP/DEBIAN
 cp -rf DEBIAN $TMP
+chmod 775 $TMP/DEBIAN/postinst
 dpkg -b $TMP $OUTPUT
 


### PR DESCRIPTION
Fixed error "dpkg-deb: error: maintainer script 'postinst' has bad permissions 750 (must be >=0555 and <=0775)" on Debian, though i don't know why 750 is not working... it is between 555 and 775 for sure... but anyway 775 works as expected